### PR TITLE
更新项目配置和服务地址

### DIFF
--- a/BlazorWebGame.sln
+++ b/BlazorWebGame.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36121.58
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWebGame.Client", "src\BlazorWebGame.Client\BlazorWebGame.csproj", "{BDE3FF59-1823-4D7F-A8F5-DB7E6CD066F3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWebGame", "src\BlazorWebGame.Client\BlazorWebGame.csproj", "{BDE3FF59-1823-4D7F-A8F5-DB7E6CD066F3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWebGame.Server", "src\BlazorWebGame.Server\BlazorWebGame.Server.csproj", "{E4B7B9A4-8F3D-4C2E-9A1B-5F4E6D7C8B9A}"
 EndProject

--- a/src/BlazorWebGame.Client/Program.cs
+++ b/src/BlazorWebGame.Client/Program.cs
@@ -12,7 +12,7 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 // 配置HTTP客户端，指向服务器
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7290") });
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7000") });
 
 // 添加新的API服务
 builder.Services.AddScoped<GameApiService>();

--- a/src/BlazorWebGame.Client/Properties/launchSettings.json
+++ b/src/BlazorWebGame.Client/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:7070;http://localhost:5190",
+      "applicationUrl": "https://localhost:7051;http://localhost:5190",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/BlazorWebGame.Client/Services/Api/GameApiService.cs
+++ b/src/BlazorWebGame.Client/Services/Api/GameApiService.cs
@@ -10,7 +10,7 @@ public class GameApiService
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<GameApiService> _logger;
-    private string _baseUrl = "https://localhost:7290"; // 默认服务器地址
+    private string _baseUrl = "https://localhost:7000"; // 默认服务器地址
 
     public string BaseUrl => _baseUrl;
 

--- a/src/BlazorWebGame.Server/Program.cs
+++ b/src/BlazorWebGame.Server/Program.cs
@@ -12,12 +12,14 @@ builder.Services.AddSwaggerGen();
 // 添加 SignalR
 builder.Services.AddSignalR();
 
-// 添加 CORS 支持
+// 修改 CORS 支持
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.WithOrigins("https://localhost:7051", "http://localhost:5000")
+        policy.WithOrigins(
+                "https://localhost:7051",  // 客户端 HTTPS
+                "http://localhost:5190")   // 客户端 HTTP
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials();

--- a/src/BlazorWebGame.Server/Properties/launchSettings.json
+++ b/src/BlazorWebGame.Server/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7195;http://localhost:5239",
+      "applicationUrl": "https://localhost:7000;http://localhost:5239",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- 在解决方案文件中新增了 `BlazorWebGame` 项目。
- 修改了 HTTP 客户端基础地址为 `https://localhost:7000`。
- 添加了新的 API 服务 `GameApiService`。
- 更新了 CORS 配置，调整了允许的来源地址。
- 修改了 `launchSettings.json` 中的 `applicationUrl` 和 `launchBrowser` 配置。
- 更新了 `GameApiService` 的默认服务器地址。